### PR TITLE
Update the command drupal:cache:clear to be re-runnable after invoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Capdrupal Changelog
 
+## NEXT RELEASE
+ - Update the command `drupal:cache:clear` to be re-runnable after invoke
+
 ## 3.0.0 (2020-08-07)
  - Support for Drupal 8 & Drupal 9
  - Complete code refactoring

--- a/lib/capdrupal.rb
+++ b/lib/capdrupal.rb
@@ -110,6 +110,7 @@ namespace :drupal do
           execute :drush, 'cr'
         end
       end
+      Rake::Task['drupal:cache:clear'].reenable
     end
   end
 


### PR DESCRIPTION
### 💬 Describe the pull request
In may Drupal project, we want to run `drupal:cache:clear` more than once.
Unfortunattely, Rake does not allow this kind of behavior. Indeed, a task must run only once.

Therefore, in a deployment calling multiple times `drupal:cache:clear`, the command will only run the first time.

With the following change, the command is re-runable any number of times.

### 🔖 Does it need an entry in the CHANGELOG ?
 - [x] Update the "NEXT RELEASE" section of the `CHANGELOG.md`
