### PR TITLE
Optimize permissions related tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## NEXT RELEASE
  - Allow Site directory to be configured
+ - Optimize permissions related tasks
 
 ## 3.0.1 (2020-08-07)
  - Update the command `drupal:cache:clear` to be re-runnable after invoke

--- a/lib/capdrupal.rb
+++ b/lib/capdrupal.rb
@@ -211,11 +211,9 @@ namespace :drupal do
     task :recommended do
       on roles(:app) do
         within release_path.join(fetch(:app_path)) do
-          execute :chmod, '-R', '555', '.'
-
           # Remove execution for files, keep execution on folder.
-          execute 'find', './ -type f -executable -exec chmod -x {} \;'
-          execute 'find', './ -type d -exec chmod +x {} \;'
+          execute :find, './', '-type f ! -perm 444 -exec chmod 444 {} \;'
+          execute :find, './', '-type d ! -perm 555 -exec chmod 555 {} \;'
         end
       end
     end
@@ -249,12 +247,10 @@ namespace :drupal do
     task :writable_shared do
       on roles(:app) do
         within shared_path do
-          # "web/sites/#{fetch(:site_path)}/files" is a shared dir and should be writable.
-          execute :chmod, '-R', '775', "#{fetch(:app_path)}/sites/#{fetch(:site_path)}/files"
-
           # Remove execution for files, keep execution on folder.
-          execute 'find', "#{fetch(:app_path)}/sites/#{fetch(:site_path)}/files", '-type f -executable -exec chmod -x {} \;'
-          execute 'find', "#{fetch(:app_path)}/sites/#{fetch(:site_path)}/files", '-type d -exec chmod +sx {} \;'
+          # "web/sites/defaults/files" is a shared dir and should be writable.
+          execute :find, './', '-type f ! -perm 664 -exec chmod 664 {} \;'
+          execute :find, './', '-type d ! -perm 2775 -exec chmod 2775 {} \;'
         end
       end
     end


### PR DESCRIPTION
### 💬 Describe the pull request/code changes
Current permissions-related tasks start by setting weak permissions on files before fixing them. Using the find command only allows us to avoid this step for more security and also speeds up the process (mainly on public files directory `permissions:recommended`).

### 🔢 To Review
_Steps to review the PR:_
1. Change permissions on some files and directories to some fancy combinations
2. Run the commands `cap [environment] permissions:recommended` and `cap [environment] permissions:writable_shared`
3. Have a look to your files and check if permissions are set as expected :
   * 664 (-rw-rw-r--) on files in the public file directory (`web/sites/default/files`
   * 2775 (drwsrwsr-x) on directories in the public file directory (`web/sites/default/files`)
   * 444 (-r--r--r--) on any other file part of the release (like `web/index.php` or `web/.htaccess`)
   * 555 (dr-xr-xr-x) on any other directory part of the release (like `web`)
