### PR TITLE
Only uploaded file directory should be Writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Capdrupal Changelog
 
 ## NEXT RELEASE
+ - Only files directory must have permissions fixed to be writable, not all shared files.
 
 ## 3.0.2 (2022-12-22)
  - Allow Site directory to be configured

--- a/lib/capdrupal.rb
+++ b/lib/capdrupal.rb
@@ -249,8 +249,8 @@ namespace :drupal do
         within shared_path do
           # Remove execution for files, keep execution on folder.
           # "web/sites/defaults/files" is a shared dir and should be writable.
-          execute :find, './', '-type f ! -perm 664 -exec chmod 664 {} \;'
-          execute :find, './', '-type d ! -perm 2775 -exec chmod 2775 {} \;'
+          execute :find, "#{fetch(:app_path)}/sites/#{fetch(:site_path)}/files", '-type f ! -perm 664 -exec chmod 664 {} \;'
+          execute :find, "#{fetch(:app_path)}/sites/#{fetch(:site_path)}/files", '-type d ! -perm 2775 -exec chmod 2775 {} \;'
         end
       end
     end


### PR DESCRIPTION
### 💬 Describe the pull request/code changes
A mistake that makes all files in the shared directory writable, but only the file directory must have permissions fixed.

close #43