### PR TITLE
Update rake require to version 12.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## NEXT RELEASE
 
+## 3.0.5 (2023-09-05)
+ - Remove `rake` dependency following security issue (to follow capitrano requirement)
+
 ## 3.0.4 (2023-04-25)
  - add command `drupal:security:obscurity:files` to obfuscate Drupal sensitive files by deletion
  - add command `drupal:security:obscurity:htaccess` to obfuscate Drupal sensitive files by htaccess

--- a/capdrupal.gemspec
+++ b/capdrupal.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'capdrupal'
-  spec.version       = '3.0.4'
+  spec.version       = '3.0.5'
   spec.authors       = ['Kevin Wenger', 'Yann Lugrin', 'Gilles Doge', 'Toni Fisler', 'Simon Perdrisat', 'Robert Wohleb', 'Kim Pepper']
   spec.email         = ['hello@antistatique.net']
 
@@ -25,5 +25,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capistrano-composer', '~> 0.0.6'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rake', '>= 12.3.3'
 end

--- a/capdrupal.gemspec
+++ b/capdrupal.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capistrano-composer', '~> 0.0.6'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rake', '~> 10.0.0'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
 end


### PR DESCRIPTION
There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |.